### PR TITLE
fix: remove geolocation behavior from reset button

### DIFF
--- a/src/atomicui/organisms/CustomRequest/index.tsx
+++ b/src/atomicui/organisms/CustomRequest/index.tsx
@@ -205,33 +205,6 @@ export default function CustomRequest({ onResponseReceived, onReset, mapRef, isE
 		setMapPoliticalView(MAP_POLITICAL_VIEWS[0]);
 		setMapLanguage(MAP_LANGUAGES[0]);
 
-		if ("geolocation" in navigator) {
-			navigator.geolocation.getCurrentPosition(
-				currentLocation => {
-					const {
-						coords: { latitude, longitude }
-					} = currentLocation;
-
-					setCurrentLocation({ currentLocation: { latitude, longitude }, error: undefined });
-					setViewpoint({ latitude, longitude });
-
-					mapRef?.current?.flyTo({
-						center: [longitude, latitude],
-						zoom: 15,
-						duration: 2000
-					});
-				},
-				error => {
-					console.warn("Failed to get current location:", error);
-					setCurrentLocation({ currentLocation: undefined, error });
-				},
-				{
-					maximumAge: 0,
-					enableHighAccuracy: true
-				}
-			);
-		}
-
 		setUrlState(null as any);
 		onReset?.();
 	};


### PR DESCRIPTION
- Remove navigator.geolocation.getCurrentPosition() call from handleReset function
- Reset button now only resets form fields without getting current location
- Maintains form field reset functionality while preserving user's map position
- Fixes issue where reset button was taking users to their current location